### PR TITLE
Fix bullseye OS builds

### DIFF
--- a/.github/workflows/experimental.yml
+++ b/.github/workflows/experimental.yml
@@ -37,7 +37,7 @@ jobs:
         uses: FranzDiebold/github-env-vars-action@v2.7.0
 
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
@@ -121,7 +121,7 @@ jobs:
         run: echo "DATE_STAMP=$(date +'%Y-%m-%d')" >> $GITHUB_ENV
 
       - name: Upload OS zip contents
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: pi-topOS_${{ env.DISTRO_NAME }}_${{ env.REPO_NAME }}_${{ env.BUILD_TYPE }}_${{ env.DATE_STAMP }}_B${{ github.run_number || github.run_id }}
           if-no-files-found: error

--- a/.github/workflows/pt-os.yml
+++ b/.github/workflows/pt-os.yml
@@ -32,7 +32,7 @@ jobs:
         uses: FranzDiebold/github-env-vars-action@v2.7.0
 
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
@@ -115,7 +115,7 @@ jobs:
         run: echo "DATE_STAMP=$(date +'%Y-%m-%d')" >> $GITHUB_ENV
 
       - name: Upload OS zip contents
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: pi-topOS_${{ inputs.distro_name }}_${{ inputs.repo_name }}_${{ env.BUILD_TYPE }}_${{ env.DATE_STAMP }}_B${{ github.run_number || github.run_id }}
           if-no-files-found: error

--- a/playbooks/install_pi_top_os.yml
+++ b/playbooks/install_pi_top_os.yml
@@ -86,6 +86,11 @@
         dest: /recovery/autoboot.txt
         mode: '0755'
 
+    - name: Prevent systemd services from restarting during upgrade
+      shell: |
+        dpkg-divert --add --rename /usr/sbin/invoke-rc.d
+        ln -s /bin/true /usr/sbin/invoke-rc.d
+
     # TODO: move to a new stage
     - name: Update all packages to the latest version
       apt:
@@ -94,3 +99,8 @@
       register: apt_status
       retries: 5
       until: apt_status is success
+
+    - name: Restore invoke-rc.d
+      shell: |
+        rm /usr/sbin/invoke-rc.d
+        dpkg-divert --remove --rename /usr/sbin/invoke-rc.d


### PR DESCRIPTION
- Bump workflow actions versions.
- Don't allow starting/restarting systemd services during upgrade; this fixes an issue in the final step of the build process where the image can't be unmounted due to some services running in the background.